### PR TITLE
Fix #1 Long words cause horizontal scrolling on narrow screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,7 @@
 body {
   margin: 0 auto;
   max-width: 40rem;
+  overflow-wrap: break-word;
   padding: 1rem;
   background-color: #ffe;
   color: #111;


### PR DESCRIPTION
* break long words to prevent overflow